### PR TITLE
Add GH Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    name: Test / OS ${{ matrix.platform }} / Node ${{ matrix.node }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ubuntu-latest]
+        node: [12.x]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up DB
+        run: docker-compose up -d
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - run: npm install
+
+      - run: npm run dev &
+
+      - name: Sleep for 30s
+        uses: jakejarvis/wait-action@v0.1.0
+        with:
+          time: '30s'
+
+      - run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  release:
+    name: Release / Node ${{ matrix.node }}
+
+    strategy:
+      matrix:
+        node: ['14']
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Prepare release
+        run: |
+          npm install
+          npm run dist
+          tar -czvf pg-api-linux.tar.gz -C ./bin start-linux
+          tar -czvf pg-api-macos.tar.gz -C ./bin start-macos
+          tar -czvf pg-api-windows.tar.gz -C ./bin start-win.exe
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+
+      - name: Upload linux release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./pg-api-linux.tar.gz
+          asset_name: pg-api-linux.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload macos release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./pg-api-macos.tar.gz
+          asset_name: pg-api-macos.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Upload windows release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./pg-api-windows.tar.gz
+          asset_name: pg-api-windows.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Fly.io deploy
+        uses: superfly/flyctl-actions@1.0
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        with:
+          args: 'deploy'


### PR DESCRIPTION
Automates testing, building, releasing binary and deploying to fly.io up tag push. (Needs a secret: FLY_API_TOKEN)

I tried finding a release notes generator, but couldn't find one that "works" (generate changelog into Releases body upon tag push). Candidates were:

- [Release Drafter](https://github.com/release-drafter/release-drafter)
It can generate drafts of changelog upon push to branches, but it can't handle tag pushes
- [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator) or [zeit/release](https://github.com/zeit/release)
Looks good, but they're manually triggered (not GitHub Actions)
- [release-notary](https://github.com/aevea/release-notary)
This one seems to do exactly what I want, but it errors out and gives undecipherable error messages that I couldn't debug

(I wish I didn't spend so much time on this...)

Closes #1, #2, #3.