### PR TITLE
fix: request query parameter handling

### DIFF
--- a/src/api/columns.ts
+++ b/src/api/columns.ts
@@ -5,15 +5,23 @@ import sql = require('../lib/sql')
 import { DEFAULT_SYSTEM_SCHEMAS } from '../lib/constants'
 import { Tables } from '../lib/interfaces'
 
+/**
+ * @param {boolean} [includeSystemSchemas=false] - Return system schemas as well as user schemas
+ */
+interface QueryParams {
+  includeSystemSchemas?: string
+}
+
 const router = Router()
 const { columns, tables } = sql
 
 router.get('/', async (req, res) => {
   try {
     const { data } = await RunQuery(req.headers.pg, columns)
-    const query: Fetch.QueryParams = req.query
+    const query: QueryParams = req.query
+    const includeSystemSchemas = query?.includeSystemSchemas === 'true'
     let payload: Tables.Column[] = data
-    if (!query?.includeSystemSchemas) payload = removeSystemSchemas(data)
+    if (!includeSystemSchemas) payload = removeSystemSchemas(data)
     return res.status(200).json(payload)
   } catch (error) {
     console.log('throwing error')
@@ -104,8 +112,6 @@ router.delete('/:id', async (req, res) => {
   }
 })
 
-export = router
-
 const removeSystemSchemas = (data: Tables.Column[]) => {
   return data.filter((x) => !DEFAULT_SYSTEM_SCHEMAS.includes(x.schema))
 }
@@ -132,14 +138,4 @@ ${is_nullable ? '' : 'NOT NULL'}
 ${is_primary_key ? 'PRIMARY KEY' : ''}`
 }
 
-/**
- * Types
- */
-namespace Fetch {
-  /**
-   * @param {boolean} [includeSystemSchemas=false] - Return system schemas as well as user schemas
-   */
-  export interface QueryParams {
-    includeSystemSchemas?: boolean
-  }
-}
+export = router

--- a/src/api/functions.ts
+++ b/src/api/functions.ts
@@ -6,13 +6,21 @@ import { RunQuery } from '../lib/connectionPool'
 import { DEFAULT_SYSTEM_SCHEMAS } from '../lib/constants'
 import { Functions } from '../lib/interfaces'
 
+/**
+ * @param {boolean} [includeSystemSchemas=false] - Return system schemas as well as user schemas
+ */
+interface QueryParams {
+  includeSystemSchemas?: string
+}
+
 const router = Router()
 router.get('/', async (req, res) => {
   try {
     const { data } = await RunQuery(req.headers.pg, functions)
-    const query: Fetch.QueryParams = req.query
+    const query: QueryParams = req.query
+    const includeSystemSchemas = query?.includeSystemSchemas === 'true'
     let payload: Functions.Function[] = data
-    if (!query?.includeSystemSchemas) payload = removeSystemSchemas(data)
+    if (!includeSystemSchemas) payload = removeSystemSchemas(data)
     return res.status(200).json(payload)
   } catch (error) {
     console.log('throwing error')
@@ -25,16 +33,3 @@ const removeSystemSchemas = (data: Functions.Function[]) => {
 }
 
 export = router
-
-/**
- * Types
- */
-
-namespace Fetch {
-  /**
-   * @param {boolean} [includeSystemSchemas=false] - Return system schemas as well as user schemas
-   */
-  export interface QueryParams {
-    includeSystemSchemas?: boolean
-  }
-}

--- a/src/api/roles.ts
+++ b/src/api/roles.ts
@@ -10,12 +10,13 @@ import { Roles } from '../lib/interfaces'
 /**
  * @param {boolean} [includeSystemSchemas=false] - Return system schemas as well as user schemas
  */
-interface GetRolesQueryParams {
-  includeDefaultRoles?: boolean
-  includeSystemSchemas?: boolean
+interface QueryParams {
+  includeDefaultRoles?: string
+  includeSystemSchemas?: string
 }
 
 const router = Router()
+
 router.get('/', async (req, res) => {
   try {
     const sql = `
@@ -27,10 +28,12 @@ SELECT
 FROM
   roles`
     const { data } = await RunQuery(req.headers.pg, sql)
-    const query: GetRolesQueryParams = req.query
+    const query: QueryParams = req.query
+    const includeSystemSchemas = query?.includeSystemSchemas === 'true'
+    const includeDefaultRoles = query?.includeDefaultRoles === 'true'
     let payload: Roles.Role[] = data
-    if (!query?.includeSystemSchemas) payload = removeSystemSchemas(data)
-    if (!query?.includeDefaultRoles) payload = removeDefaultRoles(payload)
+    if (!includeSystemSchemas) payload = removeSystemSchemas(data)
+    if (!includeDefaultRoles) payload = removeDefaultRoles(payload)
 
     return res.status(200).json(payload)
   } catch (error) {
@@ -38,6 +41,7 @@ FROM
     res.status(500).json({ error: 'Database error', status: 500 })
   }
 })
+
 router.post('/', async (req, res) => {
   try {
     const {

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -10,8 +10,8 @@ const { schemas } = sqlTemplates
 /**
  * @param {boolean} [includeSystemSchemas=false] - Return system schemas as well as user schemas
  */
-interface GetSchemasQueryParams {
-  includeSystemSchemas?: boolean
+interface QueryParams {
+  includeSystemSchemas?: string
 }
 
 const router = Router()
@@ -19,9 +19,10 @@ const router = Router()
 router.get('/', async (req, res) => {
   try {
     const { data } = await RunQuery(req.headers.pg, schemas)
-    const query: GetSchemasQueryParams = req.query
+    const query: QueryParams = req.query
+    const includeSystemSchemas = query?.includeSystemSchemas === 'true'
     let payload: Schemas.Schema[] = data
-    if (!query?.includeSystemSchemas) payload = removeSystemSchemas(data)
+    if (!includeSystemSchemas) payload = removeSystemSchemas(data)
 
     return res.status(200).json(payload)
   } catch (error) {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -6,13 +6,22 @@ import { RunQuery } from '../lib/connectionPool'
 import { DEFAULT_SYSTEM_SCHEMAS } from '../lib/constants'
 import { Types } from '../lib/interfaces'
 
+/**
+ * @param {boolean} [includeSystemSchemas=false] - Return system schemas as well as user schemas
+ */
+interface QueryParams {
+  includeSystemSchemas?: string
+}
+
 const router = Router()
+
 router.get('/', async (req, res) => {
   try {
     const { data } = await RunQuery(req.headers.pg, types)
-    const query: Fetch.QueryParams = req.query
+    const query: QueryParams = req.query
+    const includeSystemSchemas = query?.includeSystemSchemas === 'true'
     let payload: Types.Type[] = data
-    if (!query?.includeSystemSchemas) payload = removeSystemSchemas(data)
+    if (!includeSystemSchemas) payload = removeSystemSchemas(data)
     return res.status(200).json(payload)
   } catch (error) {
     console.log('throwing error')
@@ -25,16 +34,3 @@ const removeSystemSchemas = (data: Types.Type[]) => {
 }
 
 export = router
-
-/**
- * Types
- */
-
-namespace Fetch {
-  /**
-   * @param {boolean} [includeSystemSchemas=false] - Return system schemas as well as user schemas
-   */
-  export interface QueryParams {
-    includeSystemSchemas?: boolean
-  }
-}

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -99,6 +99,12 @@ describe('/schemas', () => {
     assert.equal(true, !!datum)
     assert.equal(true, !!included)
   })
+  it('GET without system schemas (explicit)', async () => {
+    const res = await axios.get(`${URL}/schemas?includeSystemSchemas=false`)
+    const isIncluded = res.data.some((x) => x.name === 'pg_catalog')
+    assert.equal(res.status, STATUS.SUCCESS)
+    assert.equal(isIncluded, false)
+  })
   it('POST & PATCH & DELETE', async () => {
     const res = await axios.post(`${URL}/schemas`, { name: 'api' })
     assert.equal('api', res.data.name)
@@ -201,13 +207,12 @@ describe('/tables', async () => {
     assert.equal(res.status, STATUS.SUCCESS)
     assert.equal(true, !!included)
   })
-  // FIXME: Bad handling of query param in /tables & /columns & /schemas & /types
-  // it('GET /tables without system tables (explicit)', async () => {
-  //   const res = await axios.get(`${URL}/tables?includeSystemSchemas=false`)
-  //   const isIncluded = res.data.some((x) => `${x.schema}.${x.name}` === 'pg_catalog.pg_type')
-  //   assert.equal(res.status, STATUS.SUCCESS)
-  //   assert.equal(isIncluded, false)
-  // })
+  it('GET /tables without system tables (explicit)', async () => {
+    const res = await axios.get(`${URL}/tables?includeSystemSchemas=false`)
+    const isIncluded = res.data.some((x) => `${x.schema}.${x.name}` === 'pg_catalog.pg_type')
+    assert.equal(res.status, STATUS.SUCCESS)
+    assert.equal(isIncluded, false)
+  })
   it('GET /columns', async () => {
     const res = await axios.get(`${URL}/columns`)
     // console.log('res.data', res.data)


### PR DESCRIPTION
Request parameters are of the type ParsedQs (see @types/qs). Here's the
type definition:

interface ParsedQs { [key: string]: undefined | string | string[] | ParsedQs | ParsedQs[] }

Note that the params aren't converted to JS types by default.

Currently, these query params are casted to an interface with boolean
values, but TypeScript doesn't convert these string params at
runtime (rather, TypeScript is only useful on compile time), so a
`string` is used where a `boolean` is expected.

To reproduce the error, uncomment the test labelled with FIXME.