### PR TITLE
fix: don't run name-change SQL when unchanged

### DIFF
--- a/src/api/columns.ts
+++ b/src/api/columns.ts
@@ -168,7 +168,7 @@ const alterColumnSqlize = ({
   comment?: string
 }) => {
   const nameSql =
-    name === undefined
+    typeof name === 'undefined' || name === oldName
       ? ''
       : `ALTER TABLE "${schema}"."${table}" RENAME COLUMN "${oldName}" TO "${name}";`
   const typeSql =

--- a/src/api/tables.ts
+++ b/src/api/tables.ts
@@ -84,7 +84,10 @@ router.patch('/:id', async (req, res) => {
     let previousTable: Tables.Table = getTableResults[0]
 
     // Update fields and name
-    const nameSql = !name ? '' : alterTableName(previousTable.name, name, previousTable.schema)
+    const nameSql =
+      typeof name === 'undefined' || name === previousTable.name
+        ? ''
+        : alterTableName(previousTable.name, name, previousTable.schema)
     if (!name) payload.name = previousTable.name
     const alterSql = alterTableSql(payload)
     const transaction = toTransaction([nameSql, alterSql])

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -262,6 +262,16 @@ describe('/tables', async () => {
     assert.equal(updatedTable.comment, 'foo')
     await axios.delete(`${URL}/tables/${newTable.id}`)
   })
+  it('PATCH /tables same name', async () => {
+    const { data: newTable } = await axios.post(`${URL}/tables`, {
+      name: 'test',
+    })
+    let { data: updatedTable } = await axios.patch(`${URL}/tables/${newTable.id}`, {
+      name: 'test',
+    })
+    assert.equal(updatedTable.name, `test`)
+    await axios.delete(`${URL}/tables/${newTable.id}`)
+  })
   it('DELETE /tables', async () => {
     const { data: newTable } = await axios.post(`${URL}/tables`, { name: 'test' })
 
@@ -322,6 +332,23 @@ describe('/tables', async () => {
     assert.equal(updatedColumn.default_value, null)
     assert.equal(updatedColumn.is_nullable, false)
     assert.equal(updatedColumn.comment, 'bar')
+
+    await axios.delete(`${URL}/columns/${newTable.id}.1`)
+    await axios.delete(`${URL}/tables/${newTable.id}`)
+  })
+  it('PATCH /columns same name', async () => {
+    const { data: newTable } = await axios.post(`${URL}/tables`, { name: 'foo' })
+    await axios.post(`${URL}/columns`, {
+      table_id: newTable.id,
+      name: 'bar',
+      type: 'int2',
+    })
+
+    const { data: updatedColumn } = await axios.patch(`${URL}/columns/${newTable.id}.1`, {
+      name: 'bar',
+    })
+
+    assert.equal(updatedColumn.name, 'bar')
 
     await axios.delete(`${URL}/columns/${newTable.id}.1`)
     await axios.delete(`${URL}/tables/${newTable.id}`)


### PR DESCRIPTION
Covers /tables & /columns on PATCH.

Closes #44.