### PR TITLE
fix: Improve escaping of identifiers and SQL literals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -957,9 +957,9 @@
       }
     },
     "dot-prop": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-      "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+      "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
       "dev": true,
       "requires": {
         "is-obj": "^1.0.0"
@@ -2269,9 +2269,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "log-symbols": {
@@ -3026,6 +3026,12 @@
           "integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
         }
       }
+    },
+    "pg-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
+      "integrity": "sha1-J3NCNsKtP05QZJFaWTNOIAQKgo4=",
+      "dev": true
     },
     "pg-int8": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "mocha": "^7.1.2",
     "nodemon": "^1.19.4",
     "npm-run-all": "^4.1.5",
+    "pg-format": "^1.0.4",
     "pkg": "^4.4.8",
     "prettier": "^2.0.5",
     "rimraf": "^3.0.2",

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express'
+import format from 'pg-format'
 import SQL from 'sql-template-strings'
 import sqlTemplates = require('../lib/sql')
 import { RunQuery } from '../lib/connectionPool'
@@ -110,7 +111,7 @@ const selectSingleByName = (name: string) => {
   return query
 }
 const createSchema = (name: string, owner: string = 'postgres') => {
-  const query = SQL``.append(`CREATE SCHEMA IF NOT EXISTS "${name}" AUTHORIZATION ${owner}`)
+  const query = SQL``.append(`CREATE SCHEMA IF NOT EXISTS ${name} AUTHORIZATION ${owner}`)
   return query
 }
 const alterSchemaName = (previousName: string, newName: string) => {
@@ -122,7 +123,7 @@ const alterSchemaOwner = (schemaName: string, newOwner: string) => {
   return query
 }
 const dropSchemaSqlize = (name: string, cascade: boolean) => {
-  const query = `DROP SCHEMA "${name}" ${cascade ? 'CASCADE' : 'RESTRICT'}`
+  const query = `DROP SCHEMA ${format.ident(name)} ${cascade ? 'CASCADE' : 'RESTRICT'}`
   return query
 }
 const removeSystemSchemas = (data: Schemas.Schema[]) => {

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -383,6 +383,28 @@ describe('/tables', async () => {
 
     await axios.delete(`${URL}/tables/${newTable.id}`)
   })
+
+  it("allows ' in COMMENTs", async () => {
+    const { data: newTable } = await axios.post(`${URL}/tables`, { name: 'foo', comment: "'" })
+    assert.equal(newTable.comment, "'")
+
+    await axios.post(`${URL}/columns`, {
+      table_id: newTable.id,
+      name: 'bar',
+      type: 'int2',
+      comment: "'",
+    })
+
+    const { data: columns } = await axios.get(`${URL}/columns`)
+    const newColumn = columns.find(
+      (column) =>
+        column.id === `${newTable.id}.1` && column.name === 'bar' && column.format === 'int2'
+    )
+    assert.equal(newColumn.comment, "'")
+
+    await axios.delete(`${URL}/columns/${newTable.id}.1`)
+    await axios.delete(`${URL}/tables/${newTable.id}`)
+  })
 })
 // TODO: Test for schema (currently checked manually). Need a different SQL template.
 describe('/extensions', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "allowJs": true,
     "checkJs": false,
     "module": "commonjs",
-    "target": "es5"
+    "target": "es5",
+    "esModuleInterop": true
   },
   "exclude": ["node_modules", "test", "dist", "docs", "bin"]
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Closes #57.

## What is the new behavior?

pg-format is now used in most places, so using `'` in `COMMENT`s should work.