### PR TITLE
fix: table_id types mismatch

### DIFF
--- a/src/lib/sql/columns.sql
+++ b/src/lib/sql/columns.sql
@@ -1,5 +1,5 @@
 SELECT
-  c.oid AS table_id,
+  c.oid :: int8 AS table_id,
   table_schema AS schema,
   table_name AS table,
   (c.oid || '.' || ordinal_position) AS id,

--- a/src/lib/sql/grants.sql
+++ b/src/lib/sql/grants.sql
@@ -1,5 +1,5 @@
 SELECT
-  c.oid AS table_id,
+  c.oid :: int8 AS table_id,
   grantor,
   grantee,
   table_catalog AS catalog,
@@ -10,5 +10,5 @@ SELECT
   with_hierarchy :: boolean
 FROM
   information_schema.role_table_grants
-  JOIN pg_class c ON quote_ident(table_schema)::regnamespace = c.relnamespace
+  JOIN pg_class c ON quote_ident(table_schema) :: regnamespace = c.relnamespace
   AND table_name = c.relname

--- a/src/lib/sql/policies.sql
+++ b/src/lib/sql/policies.sql
@@ -2,25 +2,28 @@ select
   pol.oid as id,
   n.nspname AS schema,
   c.relname AS table,
-  c.oid AS table_id,
+  c.oid :: int8 AS table_id,
   pol.polname AS name,
   CASE
     WHEN pol.polpermissive THEN 'PERMISSIVE' :: text
     ELSE 'RESTRICTIVE' :: text
   END AS action,
   CASE
-    WHEN pol.polroles = '{0}' :: oid [] 
-    THEN array_to_json(string_to_array('public' :: text, '' :: text) :: name [])
-    ELSE array_to_json(ARRAY(
-      SELECT
-        pg_authid.rolname
-      FROM
-        pg_authid
-      WHERE
-        pg_authid.oid = ANY (pol.polroles)
-      ORDER BY
-        pg_authid.rolname
-    ))
+    WHEN pol.polroles = '{0}' :: oid [] THEN array_to_json(
+      string_to_array('public' :: text, '' :: text) :: name []
+    )
+    ELSE array_to_json(
+      ARRAY(
+        SELECT
+          pg_authid.rolname
+        FROM
+          pg_authid
+        WHERE
+          pg_authid.oid = ANY (pol.polroles)
+        ORDER BY
+          pg_authid.rolname
+      )
+    )
   END AS roles,
   CASE
     pol.polcmd

--- a/src/lib/sql/primary_keys.sql
+++ b/src/lib/sql/primary_keys.sql
@@ -2,7 +2,7 @@ SELECT
   n.nspname AS schema,
   c.oid :: regclass AS table_name,
   a.attname AS name,
-  c.oid AS table_id
+  c.oid :: int8 AS table_id
 FROM
   pg_index i,
   pg_class c,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Closes #39. Closes #56.

## What is the new behavior?

Apparently Postgres converts oid to string when converting to JSON, so we have to explicitly cast table_id columns for `columns`, `grants`, `policies`, and `primary_keys` to type int8.