### PR TITLE
Add replica identity fields to /tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dist:pkg": "rimraf bin && pkg --out-path ./bin package.json",
     "dev": "NODE_ENV=development npm-run-all build server",
     "dev:watch": "nodemon",
-    "pretty": "prettier --write \"./src/**/*.{js,json,yml,md,vue,css,scss}\"",
+    "pretty": "prettier --write \"{src,test}/**/*.ts\"",
     "server": "node ./dist/start.js",
     "test": "node -r esm ./node_modules/.bin/mocha 'test/**/*.js' --recursive "
   },

--- a/src/lib/connectionPool.ts
+++ b/src/lib/connectionPool.ts
@@ -6,7 +6,7 @@ import { SQLStatement } from 'sql-template-strings'
 pg.types.setTypeParser(20, 'text', parseInt)
 const { Pool } = pg
 
-export const RunQuery = async (connectionString: any, sql: string|SQLStatement) => {
+export const RunQuery = async (connectionString: any, sql: string | SQLStatement) => {
   const pool = new Pool({ connectionString })
   try {
     const results = await pool.query(sql)

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -65,8 +65,8 @@ export namespace Tables {
     is_typed: boolean
     bytes: number
     size: string
-    rls_enabled: boolean          // determines where RLS has been turned on 
-    rls_forced: boolean           // determines whether RLS should be forced on the table owner
+    rls_enabled: boolean // determines where RLS has been turned on
+    rls_forced: boolean // determines whether RLS should be forced on the table owner
 
     // pg_stat_all_tables columns
     sequential_scans: number

--- a/src/lib/sql/tables.sql
+++ b/src/lib/sql/tables.sql
@@ -6,6 +6,11 @@ SELECT
   is_insertable_into,
   relrowsecurity::bool as rls_enabled, 
   relforcerowsecurity as rls_forced,
+  CASE WHEN relreplident = 'd' THEN 'DEFAULT'
+       WHEN relreplident = 'i' THEN 'INDEX'
+       WHEN relreplident = 'f' THEN 'FULL'
+       ELSE 'NOTHING'
+  END AS replica_identity,
   is_typed,
   pg_total_relation_size(format('%I.%I', table_schema, table_name))::bigint AS bytes,
   pg_size_pretty(

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -250,8 +250,9 @@ describe('/tables', async () => {
     assert.equal(true, !!included)
   })
   it('POST /tables should create a table', async () => {
-    const { data: newTable } = await axios.post(`${URL}/tables`, { name: 'test', comment: 'foo' })
+    const { data: newTable } = await axios.post(`${URL}/tables`, { name: 'test', replica_identity: 'FULL', comment: 'foo' })
     assert.equal(`${newTable.schema}.${newTable.name}`, 'public.test')
+    assert.equal(newTable.replica_identity, 'FULL')
     assert.equal(newTable.comment, 'foo')
 
     const { data: tables } = await axios.get(`${URL}/tables`)
@@ -268,11 +269,13 @@ describe('/tables', async () => {
       name: 'test a',
       rls_enabled: true,
       rls_forced: true,
+      replica_identity: 'NOTHING',
       comment: 'foo',
     })
     assert.equal(updatedTable.name, `test a`)
     assert.equal(updatedTable.rls_enabled, true)
     assert.equal(updatedTable.rls_forced, true)
+    assert.equal(updatedTable.replica_identity, 'NOTHING')
     assert.equal(updatedTable.comment, 'foo')
     await axios.delete(`${URL}/tables/${newTable.id}`)
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the new behavior?

Add `replica_identity` to `/tables`. This allows e.g. setting `REPLICA IDENTITY` to `FULL` like so:

```sh
curl -X PATCH http://localhost:1337/tables/16391 -H "Content-Type: application/json" -d '{ "replica_identity": "FULL" }'
```

## Additional context

Together with #67, closes #65.