### PR TITLE
Rename row count estimates

### DIFF
--- a/src/lib/sql/tables.sql
+++ b/src/lib/sql/tables.sql
@@ -14,8 +14,8 @@ SELECT
   pg_size_pretty(
     pg_total_relation_size(format('%I.%I', nc.nspname, c.relname))
   ) AS size,
-  pg_stat_get_live_tuples(c.oid) AS live_row_count,
-  pg_stat_get_dead_tuples(c.oid) AS dead_row_count,
+  pg_stat_get_live_tuples(c.oid) AS live_rows_estimate,
+  pg_stat_get_dead_tuples(c.oid) AS dead_rows_estimate,
   obj_description(c.oid) AS comment
 FROM
   pg_namespace nc


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

Rename row count estimates from the statistics collector.

## Additional context

Closes #66.

As I mentioned in #66, we should be explicit that these numbers are estimates.

P.S. this doesn't exactly solve the problem in #66, that one needs either exact count (bad for large tables) or `ANALYZE` (but it's [automatically run](https://www.postgresql.org/docs/12/runtime-config-autovacuum.html#GUC-AUTOVACUUM-ANALYZE-THRESHOLD) for large inserts/updates/deletes by default anyway--but the user will have to wait). So... wontfix?