### PR TITLE
fix: propagate errors from Postgres

### DIFF
--- a/src/api/columns.ts
+++ b/src/api/columns.ts
@@ -26,7 +26,7 @@ router.get('/', async (req, res) => {
     return res.status(200).json(payload)
   } catch (error) {
     console.log('throwing error')
-    res.status(500).json({ error: 'Database error.', status: 500 })
+    res.status(500).json({ error: error.message })
   }
 })
 
@@ -50,7 +50,7 @@ router.post('/', async (req, res) => {
     return res.status(200).json(column)
   } catch (error) {
     console.log('throwing error', error)
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(400).json({ error: error.message })
   }
 })
 
@@ -68,7 +68,11 @@ router.patch('/:id', async (req, res) => {
     return res.status(200).json(updated)
   } catch (error) {
     console.log('throwing error', error)
-    res.status(500).json({ error: 'Database error', status: 500 })
+    if (error instanceof TypeError) {
+      res.status(404).json({ error: 'Cannot find a column with that id' })
+    } else {
+      res.status(400).json({ error: error.message })
+    }
   }
 })
 
@@ -85,7 +89,11 @@ router.delete('/:id', async (req, res) => {
     return res.status(200).json(column)
   } catch (error) {
     console.log('throwing error', error)
-    res.status(500).json({ error: 'Database error', status: 500 })
+    if (error instanceof TypeError) {
+      res.status(404).json({ error: 'Cannot find a column with that id' })
+    } else {
+      res.status(400).json({ error: error.message })
+    }
   }
 })
 

--- a/src/api/config.ts
+++ b/src/api/config.ts
@@ -11,7 +11,7 @@ router.get('/', async (req, res) => {
     return res.status(200).json(data)
   } catch (error) {
     console.log('throwing error')
-    res.status(500).json({ error: 'Database error.', status: 500 })
+    res.status(500).json({ error: error.message })
   }
 })
 router.get('/version', async (req, res) => {
@@ -20,7 +20,7 @@ router.get('/version', async (req, res) => {
     return res.status(200).json(data[0]) // only one row
   } catch (error) {
     console.log('throwing error')
-    res.status(500).json({ error: 'Database error.', status: 500 })
+    res.status(500).json({ error: error.message })
   }
 })
 

--- a/src/api/extensions.ts
+++ b/src/api/extensions.ts
@@ -14,7 +14,7 @@ router.get('/', async (req, res) => {
     return res.status(200).json(data)
   } catch (error) {
     console.log('throwing error')
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(500).json({ error: error.message })
   }
 })
 
@@ -29,7 +29,7 @@ router.post('/', async (req, res) => {
     return res.status(200).json(extension)
   } catch (error) {
     console.log('throwing error')
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(400).json({ error: error.message })
   }
 })
 
@@ -47,7 +47,7 @@ router.patch('/:name', async (req, res) => {
     return res.status(200).json(updated)
   } catch (error) {
     console.log('throwing error')
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(400).json({ error: error.message })
   }
 })
 
@@ -65,7 +65,7 @@ router.delete('/:name', async (req, res) => {
     return res.status(200).json(deleted)
   } catch (error) {
     console.log('throwing error')
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(400).json({ error: error.message })
   }
 })
 

--- a/src/api/functions.ts
+++ b/src/api/functions.ts
@@ -24,7 +24,7 @@ router.get('/', async (req, res) => {
     return res.status(200).json(payload)
   } catch (error) {
     console.log('throwing error')
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(500).json({ error: error.message })
   }
 })
 

--- a/src/api/policies.ts
+++ b/src/api/policies.ts
@@ -26,7 +26,7 @@ router.get('/', async (req, res) => {
     return res.status(200).json(payload)
   } catch (error) {
     console.log('throwing error', error)
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(500).json({ error: error.message })
   }
 })
 
@@ -106,7 +106,7 @@ router.delete('/:id', async (req, res) => {
     return res.status(200).json(policy)
   } catch (error) {
     console.log('throwing error', error)
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(400).json({ error: error.message })
   }
 })
 

--- a/src/api/roles.ts
+++ b/src/api/roles.ts
@@ -33,7 +33,7 @@ router.get('/', async (req, res) => {
     return res.status(200).json(payload)
   } catch (error) {
     console.log('throwing error')
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(500).json({ error: error.message })
   }
 })
 
@@ -48,7 +48,7 @@ router.post('/', async (req, res) => {
     return res.status(200).json(role)
   } catch (error) {
     console.log('throwing error', error)
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(400).json({ error: error.message })
   }
 })
 
@@ -68,7 +68,7 @@ router.patch('/:id', async (req, res) => {
     return res.status(200).json(updated)
   } catch (error) {
     console.log('throwing error', error)
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(400).json({ error: error.message })
   }
 })
 
@@ -85,7 +85,7 @@ router.delete('/:id', async (req, res) => {
     return res.status(200).json(role)
   } catch (error) {
     console.log('throwing error', error)
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(400).json({ error: error.message })
   }
 })
 

--- a/src/api/schemas.ts
+++ b/src/api/schemas.ts
@@ -28,7 +28,7 @@ router.get('/', async (req, res) => {
     return res.status(200).json(payload)
   } catch (error) {
     console.log('throwing error', error)
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(500).json({ error: error.message })
   }
 })
 
@@ -48,7 +48,7 @@ router.post('/', async (req, res) => {
     return res.status(200).json(schema)
   } catch (error) {
     console.log('throwing error', error)
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(400).json({ error: error.message })
   }
 })
 
@@ -80,7 +80,7 @@ router.patch('/:id', async (req, res) => {
     return res.status(200).json(updated)
   } catch (error) {
     console.log('throwing error', error)
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(400).json({ error: error.message })
   }
 })
 
@@ -97,7 +97,7 @@ router.delete('/:id', async (req, res) => {
     return res.status(200).json(schema)
   } catch (error) {
     console.log('throwing error', error)
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(400).json({ error: error.message })
   }
 })
 

--- a/src/api/tables.ts
+++ b/src/api/tables.ts
@@ -26,7 +26,7 @@ router.get('/', async (req, res) => {
     return res.status(200).json(payload)
   } catch (error) {
     console.log('throwing error', error)
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(500).json({ error: error.message })
   }
 })
 
@@ -43,7 +43,7 @@ router.get('/:id', async (req, res) => {
     return res.status(200).json(table)
   } catch (error) {
     console.log('throwing error', error)
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(400).json({ error: error.message })
   }
 })
 
@@ -119,7 +119,7 @@ router.delete('/:id', async (req, res) => {
     return res.status(200).json(table)
   } catch (error) {
     console.log('throwing error', error)
-    res.status(500).json({ error: 'Database error', status: 500 })
+    res.status(400).json({ error: error.message })
   }
 })
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -25,7 +25,7 @@ router.get('/', async (req, res) => {
     return res.status(200).json(payload)
   } catch (error) {
     console.log('throwing error')
-    res.status(500).json({ error: 'Database error.', status: 500 })
+    res.status(500).json({ error: error.message })
   }
 })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Most error responses are `500 Server Error` with error message `Database error.`, which is not very helpful.

## What is the new behavior?

Error handling goes like this:
- Baseline response on error is 400 Bad Request, propagating Postgres's error message
- If the request is infallible (e.g. GET with no payload/query params), respond with 500 Server Error, again propagating Postgres's error message
- More specific responses can be done as more specific errors are found (404 for missing IDs, etc.)