### PR TITLE
fix(columns): identity_generation missing default

### DIFF
--- a/src/api/columns.ts
+++ b/src/api/columns.ts
@@ -108,7 +108,7 @@ const addColumnSqlize = ({
   default_value,
   default_value_format = 'literal',
   is_identity = false,
-  identity_generation,
+  identity_generation = 'BY DEFAULT',
   is_nullable = true,
   is_primary_key = false,
   is_unique = false,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Missing default value for `identity_generation` in `POST /columns`. This makes requests to add columns fail when `is_identity` is `true` but `identity_generation` is unset.

## What is the new behavior?

`identity_generation` is set to `BY DEFAULT`. This is the previous behavior before support for `identity_generation` was added.