### PR TITLE
fix: allow array column type

### DIFF
--- a/src/api/columns.ts
+++ b/src/api/columns.ts
@@ -146,7 +146,7 @@ const addColumnSqlize = ({
 
   return format(
     `
-ALTER TABLE %I.%I ADD COLUMN %I %I
+ALTER TABLE %I.%I ADD COLUMN %I ${type}
   ${defaultValueSql}
   ${isIdentitySql}
   ${isNullableSql}
@@ -155,8 +155,7 @@ ALTER TABLE %I.%I ADD COLUMN %I %I
 ${commentSql}`,
     schema,
     table,
-    name,
-    type
+    name
   )
 }
 const getColumnSqlize = (tableId: number, name: string) => {
@@ -198,13 +197,11 @@ const alterColumnSqlize = (
     type === undefined
       ? ''
       : format(
-          'ALTER TABLE %I.%I ALTER COLUMN %I SET DATA TYPE %I USING %I::%I;',
+          `ALTER TABLE %I.%I ALTER COLUMN %I SET DATA TYPE ${type} USING %I::${type};`,
           old.schema,
           old.table,
           old.name,
-          type,
-          old.name,
-          type
+          old.name
         )
   let defaultValueSql: string
   if (drop_default) {

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -323,6 +323,24 @@ describe('/tables', async () => {
     await axios.delete(`${URL}/columns/${newTable.id}.1`)
     await axios.delete(`${URL}/tables/${newTable.id}`)
   })
+  it('POST /columns array type', async () => {
+    const { data: newTable } = await axios.post(`${URL}/tables`, { name: 'a' })
+    await axios.post(`${URL}/columns`, {
+      table_id: newTable.id,
+      name: 'b',
+      type: 'int2[]',
+    })
+
+    const { data: columns } = await axios.get(`${URL}/columns`)
+    const newColumn = columns.find(
+      (column) =>
+        column.id === `${newTable.id}.1` && column.name === 'b' && column.format === '_int2'
+    )
+    assert.equal(newColumn.name, 'b')
+
+    await axios.delete(`${URL}/columns/${newTable.id}.1`)
+    await axios.delete(`${URL}/tables/${newTable.id}`)
+  })
   it('/columns default_value with expressions', async () => {
     const { data: newTable } = await axios.post(`${URL}/tables`, { name: 'a' })
     const { data: newColumn } = await axios.post(`${URL}/columns`, {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Previously supplying e.g. `int4[]` as column type would error out because the brackets are treated as part of the type name (as opposed to denoting that it's an array of `int4`s).

## What is the new behavior?

Remove the quoting around `data_type`s so we can supply `foo[]` instead of `_foo`.

cc @joshenlim