### PR TITLE
feat: add schema to /extensions

### DIFF
--- a/src/lib/sql/extensions.sql
+++ b/src/lib/sql/extensions.sql
@@ -1,7 +1,9 @@
 SELECT
-  name,
-  comment,
-  default_version,
-  installed_version
+  e.name,
+  x.extnamespace :: regnamespace AS schema,
+  e.default_version,
+  x.extversion AS installed_version,
+  e.comment
 FROM
-  pg_available_extensions
+  pg_available_extensions() e(name, default_version, comment)
+  LEFT JOIN pg_extension x ON e.name = x.extname


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the new behavior?

Add `schema` field to `/extensions`. Note that an extension doesn't belong to a schema, only an extension's objects do ([ref](https://www.postgresql.org/docs/current/catalog-pg-extension.html)).