### PR TITLE
fix: convert oids to int8

### DIFF
--- a/src/lib/sql/functions.sql
+++ b/src/lib/sql/functions.sql
@@ -1,5 +1,5 @@
 select
-    p.oid as id,
+    p.oid :: int8 as id,
     n.nspname as schema,
     p.proname as name,
     l.lanname as language,

--- a/src/lib/sql/policies.sql
+++ b/src/lib/sql/policies.sql
@@ -1,5 +1,5 @@
 select
-  pol.oid as id,
+  pol.oid :: int8 as id,
   n.nspname AS schema,
   c.relname AS table,
   c.oid :: int8 AS table_id,

--- a/src/lib/sql/publications.sql
+++ b/src/lib/sql/publications.sql
@@ -1,5 +1,5 @@
 SELECT
-  p.oid AS id,
+  p.oid :: int8 AS id,
   p.pubname AS name,
   p.pubowner :: regrole AS owner,
   p.pubinsert AS publish_insert,

--- a/src/lib/sql/roles.sql
+++ b/src/lib/sql/roles.sql
@@ -1,5 +1,6 @@
 -- TODO: Consider using pg_authid vs. pg_roles for unencrypted password field
 SELECT
+  oid :: int8 AS id,
   rolname AS name,
   rolsuper AS is_superuser,
   rolcreatedb AS can_create_db,
@@ -14,8 +15,7 @@ SELECT
   END AS connection_limit,
   rolpassword AS password,
   rolvaliduntil AS valid_until,
-  rolconfig AS config,
-  oid AS id
+  rolconfig AS config
 FROM
   pg_catalog.pg_roles
   INNER JOIN LATERAL (

--- a/src/lib/sql/types.sql
+++ b/src/lib/sql/types.sql
@@ -1,5 +1,5 @@
 SELECT
-  t.oid AS id,
+  t.oid :: int8 AS id,
   t.typname AS name,
   n.nspname AS schema,
   pg_catalog.Format_type (t.oid, NULL) AS format,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Some SQL templates use `oid`, which is converted to `string` by node-postgres.

## What is the new behavior?

Convert them to `int8`.