### PR TITLE
fix: error when changing type & default at once

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@
 version: "3"
 services:
   db:
-    image: supabase/postgres
+    image: supabase/postgres:0.14.0
     ports:
       - "5432:5432"
     volumes:

--- a/src/api/columns.ts
+++ b/src/api/columns.ts
@@ -262,13 +262,14 @@ const alterColumnSqlize = (
       : format('COMMENT ON COLUMN %I.%I.%I IS %L;', old.schema, old.table, old.name, comment)
 
   // nameSql must be last.
+  // defaultValueSql must be after typeSql.
   // TODO: Can't set default if column is previously identity even if is_identity: false.
   // Must do two separate PATCHes (once to drop identity and another to set default).
   return `
 BEGIN;
   ${isNullableSql}
-  ${defaultValueSql}
   ${typeSql}
+  ${defaultValueSql}
   ${identitySql}
   ${commentSql}
   ${nameSql}

--- a/test/integration/index.spec.js
+++ b/test/integration/index.spec.js
@@ -88,7 +88,7 @@ describe('/config/version', () => {
     const res = await axios.get(`${URL}/config/version`)
     // console.log('res.data', res.data)
     assert.equal(res.status, STATUS.SUCCESS)
-    assert.equal(true, res.data.version_number == '120003')
+    assert.equal(res.data.version_number, '120005')
   })
 })
 describe('/schemas', () => {
@@ -416,6 +416,7 @@ describe('/tables', async () => {
 
     const { data: updatedColumn } = await axios.patch(`${URL}/columns/${newTable.id}.1`, {
       type: 'int4',
+      default_value: 0
     })
 
     assert.strictEqual(updatedColumn.format, 'int4')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Changing default value and type at once changes the default value *first*, i.e. for the old type, which is not what we want.

## What is the new behavior?

Change the type first.